### PR TITLE
Filter out expired artifacts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ async function downloadPreviousArtifact(octokit) {
     owner: config.owner,
     repo: config.repo,
   });
-  const firewatchArtifacts = allArtifacts.filter((x) => x.name === 'firewatch');
+  const firewatchArtifacts = allArtifacts.filter((x) => x.name === 'firewatch' && x.expired === false);
 
   if (firewatchArtifacts.length > 0) {
     firewatchArtifacts.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));


### PR DESCRIPTION
If the action is disabled and artifacts expire, the action will fail on restart as it will try download an expired one. This fix should allow the action to restart after being disabled.